### PR TITLE
chore: remove nvmrc file

### DIFF
--- a/.nvmrc~
+++ b/.nvmrc~
@@ -1,1 +1,0 @@
-lts/hydrogen


### PR DESCRIPTION
This PR removes the `nvmrc~` file as required